### PR TITLE
Release/v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## Release v0.2.2
+
+- Update API docs
+- Break AST parser out into separate module called firetree
+- Bump node-notifier from 8.0.0 to 8.0.1
+- Add .opensource. Install firetree.
+- Bump node-fetch from 2.6.0 to 2.6.1

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,3 +1,3 @@
-Copyright (c) 2020 Brian Neisler https://brianneisler.com
+Copyright (c) 2021 Brian Neisler https://brianneisler.com
 
 firemin may be freely distributed under the Apache-2.0 license.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,63 +2,94 @@
 
 This guide is a simple instruction set for releasing a new version of `firemin`
 
-
 ## Notes
+
 - We use git tags for releasing `firemin` through Travis.
 
 ## Instructions
+
 - Make sure your local master is up to date with latest commits.
+
 ```sh
 git checkout master
 git pull --rebase
 ```
+
 - Checkout a new release branch. Replace Xs with the version number you are releasing.
+
 ```sh
-git checkout -b release-vX.X.X
+git checkout -b release/vX.X.X
 ```
+
 - Update package.json to new version number
 - Cleanse project (clears out package-lock.json and installed node_modules)
+
 ```sh
 npm run cleanse
 ```
+
 - Setup project
+
 ```sh
 npm run setup
 ```
+
 - Version numbers are now updated
-- Run test to ensure tests are passing. If tests are not, abort release and fix tests.
-```sh
-npm run test
-```
+
 - run lint to ensure files have bene linted. If lint is not passing, abort release and fix lint issues.
+
 ```sh
 npm run lint
 ```
-- Update docs with new version numbers
+
+- Run test to ensure tests are passing. If tests are not, abort release and fix tests.
+
 ```sh
-npm run docs:gen
+npm run test
 ```
-- Commit file changes with new version numbers. Replace Xs with new version number.
+
+- Update docs with new version numbers
+
+```sh
+npm run docs:generate
+```
+
+- generate the change log
+
+```sh
+git log --pretty="- %s" --no-merges origin/release/vX.X.X..release/vX.X.X >> CHANGELOG.md
+```
+
+- Commit files changes with new version numbers. Replace Xs with new version number.
+
 ```sh
 git add -A
-git commit -m"Releasing vX.X.X"
-git push origin release-vX.X.X
+git commit -m"Release vX.X.X"
+git push origin release/vX.X.X
 ```
+
 - Open PR on github for new release
+- Pase changes for version from changelog into PR
 - Get PR review from core contributor
 - After reviewed and after Travis has passed build, merge PR.
 - Checkout master from git and pull version changes
+
 ```sh
 git checkout master
 git pull --rebase
 ```
+
 - Tag a new release in git
+
 ```sh
 git tag vX.X.X
 ```
+
 - Push tags
+
 ```sh
 git push --tags
 ```
+
 - Travis will release the new version from tag.
 - Relax and enjoy the new version!

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,28 +1,24 @@
 # API
 
 <!-- AUTO-GENERATED-CONTENT:START (TOC) -->
-
 - [minimizer](#minimizer)
-  - [function minimize()](#function-minimize)
+  * [function minimize()](#function-minimize)
 - [lang.util](#langutil)
-  - [**private** function cacheChain()](#private-function-cachechain)
-  - [**private** function functionDefineLength()](#private-function-functiondefinelength)
-  <!-- AUTO-GENERATED-CONTENT:END -->
+  * [**private** function cacheChain()](#private-function-cachechain)
+  * [**private** function functionDefineLength()](#private-function-functiondefinelength)
+<!-- AUTO-GENERATED-CONTENT:END -->
 
 <!-- AUTO-GENERATED-CONTENT:START (METHODS) -->
-
 ## minimizer
 
 ### function minimize()
 
-[source](https://github.com/brianneisler/firemin.git/tree/v0.2.1/src/minimizer/minimize.js#L8)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; since v0.1.0
-
+[source](https://github.com/brianneisler/firemin.git/tree/v0.2.2/src/minimizer/minimize.js#L8)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; since v0.1.0
 <p>Minimizes the rules contained at the given filePath.<br />
 If given an outputFilePath this method will output the result to the given<br />
 file path instead of returning a minimize string.</p>
 
 **Params**
-
 <p><code>context</code>: <code>Context</code> - </p>
 <p><code>options</code>: <code>{<br />
   filePath: String,<br />
@@ -33,7 +29,6 @@ file path instead of returning a minimize string.</p>
 <br /><p><code>String | Null</code> - </p>
 
 **Example**
-
 ```js
 const context = setupContext()
 
@@ -48,15 +43,13 @@ await minimize(context, {
   outputFilePath: './path/to/firestore.min.rules'
 })
 ```
-
 <br /><br />
 
 ## lang.util
 
 ### **private** function cacheChain()
 
-[source](https://github.com/brianneisler/firemin.git/tree/v0.2.1/src/utils/cacheChain.js#L42)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; since v0.1.0
-
+[source](https://github.com/brianneisler/firemin.git/tree/v0.2.2/src/utils/cacheChain.js#L42)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; since v0.1.0
 <p>This method generates a specific object instance for use in a WeakMap cache.<br />
 The object instance is unique based upon the parameters that are passed to<br />
 the this method.</p>
@@ -67,29 +60,24 @@ WeakMap as part of a chain. If that object is ever removed from memory all<br />
 cache chains connected to the object will automatically be removed from the cache.</p>
 
 **Params**
-
 <p><code>args</code>: <code>...&ast;</code> - The arguments to generate a cache key for</p>
 
 **Returns**
 <br /><p><code>Object</code> - The cache key</p>
 
 **Example**
-
 ```js
 
 ```
-
 <br /><br />
 
 ### **private** function functionDefineLength()
 
-[source](https://github.com/brianneisler/firemin.git/tree/v0.2.1/src/utils/functionDefineLength.js#L55)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; since v0.1.0
-
+[source](https://github.com/brianneisler/firemin.git/tree/v0.2.2/src/utils/functionDefineLength.js#L55)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; since v0.1.0
 <p>Defines <code>length</code> for the given <code>func</code></p>
 <p>Note: This mutates <code>func</code></p>
 
 **Params**
-
 <p><code>func</code>: <code>Function</code> - The function to define the length of.</p>
 <p><code>length</code>: <code>Number</code> - The length of the function parameters.</p>
 
@@ -97,13 +85,12 @@ cache chains connected to the object will automatically be removed from the cach
 <br /><p><code>Function</code> - The `func` function.</p>
 
 **Example**
-
 ```js
-const result = functionDefineLength(function (abc) {}, 2)
+const result = functionDefineLength(function(abc) {}, 2)
 result.length
 //=> 2
 ```
-
 <br /><br />
+
 
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firemin",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -37,12 +37,12 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.8.3"
+        "@babel/highlight": "^7.12.13"
       }
     },
     "@babel/compat-data": {
@@ -75,127 +75,6 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.12.13"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.13.9",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
-          "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.13.0",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-          "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.12.13",
-            "@babel/template": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-          "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-          "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-          "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/parser": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-          "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/generator": "^7.13.9",
-            "@babel/helper-function-name": "^7.12.13",
-            "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.13",
-            "@babel/types": "^7.13.13",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
         "debug": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -226,14 +105,13 @@
       }
     },
     "@babel/generator": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
-      "integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
+      "version": "7.13.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+      "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.9.5",
+        "@babel/types": "^7.13.0",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
         "source-map": "^0.5.0"
       },
       "dependencies": {
@@ -252,25 +130,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.12.13"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -281,25 +140,6 @@
       "requires": {
         "@babel/helper-explode-assignable-expression": "^7.12.13",
         "@babel/types": "^7.12.13"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-compilation-targets": {
@@ -333,102 +173,6 @@
         "@babel/helper-optimise-call-expression": "^7.12.13",
         "@babel/helper-replace-supers": "^7.13.0",
         "@babel/helper-split-export-declaration": "^7.12.13"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.12.13"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-          "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.12.13",
-            "@babel/template": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-          "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-          "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-          "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/parser": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
@@ -457,127 +201,6 @@
         "semver": "^6.1.2"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.12.13"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.13.9",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
-          "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.13.0",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-          "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.12.13",
-            "@babel/template": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-          "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-          "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-          "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/parser": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-          "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/generator": "^7.13.9",
-            "@babel/helper-function-name": "^7.12.13",
-            "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.13",
-            "@babel/types": "^7.13.13",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
         "debug": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -598,12 +221,6 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         }
       }
     },
@@ -614,45 +231,26 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.13.0"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
-      "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.8.3",
-        "@babel/template": "^7.8.3",
-        "@babel/types": "^7.9.5"
+        "@babel/helper-get-function-arity": "^7.12.13",
+        "@babel/template": "^7.12.13",
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-      "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -663,150 +261,6 @@
       "requires": {
         "@babel/traverse": "^7.13.0",
         "@babel/types": "^7.13.0"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.12.13"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.13.9",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
-          "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.13.0",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-          "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.12.13",
-            "@babel/template": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-          "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-          "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-          "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/parser": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-          "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/generator": "^7.13.9",
-            "@babel/helper-function-name": "^7.12.13",
-            "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.13",
-            "@babel/types": "^7.13.13",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -816,25 +270,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.13.12"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-module-imports": {
@@ -844,25 +279,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.13.12"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-module-transforms": {
@@ -879,150 +295,6 @@
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.13.0",
         "@babel/types": "^7.13.12"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.12.13"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.13.9",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
-          "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.13.0",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-          "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.12.13",
-            "@babel/template": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-          "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-          "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-          "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/parser": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-          "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/generator": "^7.13.9",
-            "@babel/helper-function-name": "^7.12.13",
-            "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.13",
-            "@babel/types": "^7.13.13",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -1032,25 +304,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.12.13"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-plugin-utils": {
@@ -1068,25 +321,6 @@
         "@babel/helper-annotate-as-pure": "^7.12.13",
         "@babel/helper-wrap-function": "^7.13.0",
         "@babel/types": "^7.13.0"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-replace-supers": {
@@ -1099,150 +333,6 @@
         "@babel/helper-optimise-call-expression": "^7.12.13",
         "@babel/traverse": "^7.13.0",
         "@babel/types": "^7.13.12"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.12.13"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.13.9",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
-          "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.13.0",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-          "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.12.13",
-            "@babel/template": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-          "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-          "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-          "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/parser": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-          "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/generator": "^7.13.9",
-            "@babel/helper-function-name": "^7.12.13",
-            "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.13",
-            "@babel/types": "^7.13.13",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
       }
     },
     "@babel/helper-simple-access": {
@@ -1252,25 +342,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.13.12"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-skip-transparent-expression-wrappers": {
@@ -1280,40 +351,21 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.12.1"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+      "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -1332,150 +384,6 @@
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.13.0",
         "@babel/types": "^7.13.0"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.12.13"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.13.9",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
-          "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.13.0",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-          "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.12.13",
-            "@babel/template": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-          "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-          "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-          "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/parser": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-          "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/generator": "^7.13.9",
-            "@babel/helper-function-name": "^7.12.13",
-            "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.13",
-            "@babel/types": "^7.13.13",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
       }
     },
     "@babel/helpers": {
@@ -1487,159 +395,15 @@
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.13.0",
         "@babel/types": "^7.13.0"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.12.13"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.13.9",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
-          "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.13.0",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-          "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.12.13",
-            "@babel/template": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-          "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-          "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-          "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/parser": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-          "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/generator": "^7.13.9",
-            "@babel/helper-function-name": "^7.12.13",
-            "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.13",
-            "@babel/types": "^7.13.13",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
       }
     },
     "@babel/highlight": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
-      "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.9.0",
+        "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -1680,9 +444,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.9.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-      "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
       "dev": true
     },
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
@@ -2008,102 +772,6 @@
         "@babel/helper-replace-supers": "^7.13.0",
         "@babel/helper-split-export-declaration": "^7.12.13",
         "globals": "^11.1.0"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.12.13"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-          "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.12.13",
-            "@babel/template": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-          "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-          "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-          "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/parser": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
       }
     },
     "@babel/plugin-transform-computed-properties": {
@@ -2170,93 +838,6 @@
       "requires": {
         "@babel/helper-function-name": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.12.13"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.12.13"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-          "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.12.13",
-            "@babel/template": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-          "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-          "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/parser": "^7.12.13",
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
       }
     },
     "@babel/plugin-transform-literals": {
@@ -2311,14 +892,6 @@
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-validator-identifier": "^7.12.11",
         "babel-plugin-dynamic-import-node": "^2.3.3"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        }
       }
     },
     "@babel/plugin-transform-modules-umd": {
@@ -2537,23 +1110,6 @@
         "semver": "^6.3.0"
       },
       "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-          "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -2598,40 +1154,39 @@
       }
     },
     "@babel/template": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-      "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+      "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/parser": "^7.8.6",
-        "@babel/types": "^7.8.6"
+        "@babel/code-frame": "^7.12.13",
+        "@babel/parser": "^7.12.13",
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/traverse": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
-      "integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+      "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.9.5",
-        "@babel/helper-function-name": "^7.9.5",
-        "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.9.0",
-        "@babel/types": "^7.9.5",
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.13.9",
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/parser": "^7.13.13",
+        "@babel/types": "^7.13.13",
         "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.13"
+        "globals": "^11.1.0"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
@@ -2643,13 +1198,13 @@
       }
     },
     "@babel/types": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-      "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
+      "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.9.5",
-        "lodash": "^4.17.13",
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -2854,12 +1409,6 @@
             "to-regex-range": "^5.0.1"
           }
         },
-        "graceful-fs": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-          "dev": true
-        },
         "is-number": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2963,12 +1512,6 @@
         "v8-to-istanbul": "^7.0.0"
       },
       "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-          "dev": true
-        },
         "slash": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -2986,14 +1529,6 @@
         "callsites": "^3.0.0",
         "graceful-fs": "^4.2.4",
         "source-map": "^0.6.0"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-          "dev": true
-        }
       }
     },
     "@jest/test-result": {
@@ -3019,14 +1554,6 @@
         "jest-haste-map": "^26.6.2",
         "jest-runner": "^26.6.3",
         "jest-runtime": "^26.6.3"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-          "dev": true
-        }
       }
     },
     "@jest/transform": {
@@ -3069,12 +1596,6 @@
           "requires": {
             "to-regex-range": "^5.0.1"
           }
-        },
-        "graceful-fs": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-          "dev": true
         },
         "is-number": {
           "version": "7.0.0",
@@ -3660,12 +2181,6 @@
         "slash": "^3.0.0"
       },
       "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-          "dev": true
-        },
         "slash": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4963,36 +3478,6 @@
             "@babel/highlight": "^7.10.4"
           }
         },
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            }
-          }
-        },
         "cross-spawn": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -5035,15 +3520,6 @@
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
-          }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
           }
         },
         "ms": {
@@ -5096,12 +3572,6 @@
           "requires": {
             "isexe": "^2.0.0"
           }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
         }
       }
     },
@@ -5215,16 +3685,6 @@
             "esutils": "^2.0.2",
             "isarray": "^1.0.0"
           }
-        },
-        "resolve": {
-          "version": "1.20.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
-          }
         }
       }
     },
@@ -5275,9 +3735,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true
     },
     "espree": {
@@ -5289,14 +3749,6 @@
         "acorn": "^7.4.0",
         "acorn-jsx": "^5.3.1",
         "eslint-visitor-keys": "^1.3.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
       }
     },
     "esprima": {
@@ -5788,14 +4240,14 @@
       }
     },
     "fs-extra": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
+        "universalify": "^2.0.0"
       }
     },
     "fs-readdir-recursive": {
@@ -5953,9 +4405,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -5991,7 +4443,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "gulp-header": {
       "version": "1.8.12",
@@ -6708,6 +5161,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -6854,12 +5308,6 @@
         "jest-cli": "^26.6.3"
       },
       "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-          "dev": true
-        },
         "jest-cli": {
           "version": "26.6.3",
           "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
@@ -7022,12 +5470,6 @@
             "to-regex-range": "^5.0.1"
           }
         },
-        "graceful-fs": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-          "dev": true
-        },
         "is-number": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -7174,12 +5616,6 @@
             "to-regex-range": "^5.0.1"
           }
         },
-        "graceful-fs": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-          "dev": true
-        },
         "is-number": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -7290,12 +5726,6 @@
             "to-regex-range": "^5.0.1"
           }
         },
-        "graceful-fs": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-          "dev": true
-        },
         "is-number": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -7377,12 +5807,6 @@
             "path-exists": "^4.0.0"
           }
         },
-        "graceful-fs": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-          "dev": true
-        },
         "locate-path": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -7450,16 +5874,6 @@
             "type-fest": "^0.8.1"
           }
         },
-        "resolve": {
-          "version": "1.20.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
-          }
-        },
         "slash": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -7505,14 +5919,6 @@
         "jest-worker": "^26.6.2",
         "source-map-support": "^0.5.6",
         "throat": "^5.0.0"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-          "dev": true
-        }
       }
     },
     "jest-runtime": {
@@ -7550,12 +5956,6 @@
         "yargs": "^15.4.1"
       },
       "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-          "dev": true
-        },
         "slash": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -7578,14 +5978,6 @@
       "requires": {
         "@types/node": "*",
         "graceful-fs": "^4.2.4"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-          "dev": true
-        }
       }
     },
     "jest-snapshot": {
@@ -7612,21 +6004,6 @@
         "semver": "^7.3.2"
       },
       "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -7635,12 +6012,6 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
         }
       }
     },
@@ -7675,12 +6046,6 @@
           "requires": {
             "to-regex-range": "^5.0.1"
           }
-        },
-        "graceful-fs": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-          "dev": true
         },
         "is-number": {
           "version": "7.0.0",
@@ -7797,9 +6162,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -7830,13 +6195,13 @@
       }
     },
     "jsdom": {
-      "version": "16.5.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.5.1.tgz",
-      "integrity": "sha512-pF73EOsJgwZekbDHEY5VO/yKXUkab/DuvrQB/ANVizbr6UAHJsDdHXuotZYwkJSGQl1JM+ivXaqY+XBDDL4TiA==",
+      "version": "16.5.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.5.2.tgz",
+      "integrity": "sha512-JxNtPt9C1ut85boCbJmffaQ06NBnzkQY/MWO3YxPW8IWS38A26z+B1oBvA9LwKrytewdfymnhi4UNH3/RAgZrg==",
       "dev": true,
       "requires": {
         "abab": "^2.0.5",
-        "acorn": "^8.0.5",
+        "acorn": "^8.1.0",
         "acorn-globals": "^6.0.0",
         "cssom": "^0.4.4",
         "cssstyle": "^2.3.0",
@@ -7858,7 +6223,7 @@
         "webidl-conversions": "^6.1.0",
         "whatwg-encoding": "^1.0.5",
         "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^8.0.0",
+        "whatwg-url": "^8.5.0",
         "ws": "^7.4.4",
         "xml-name-validator": "^3.0.0"
       },
@@ -7917,12 +6282,12 @@
       }
     },
     "jsonfile": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-      "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "requires": {
         "graceful-fs": "^4.1.6",
-        "universalify": "^1.0.0"
+        "universalify": "^2.0.0"
       }
     },
     "jsprim": {
@@ -8351,6 +6716,15 @@
         "wrap-ansi": "^6.2.0"
       }
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -8694,6 +7068,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.2.tgz",
       "integrity": "sha512-oJP/9NAdd9+x2Q+rfphB2RJCHjod70RcRLjosiPMMu5gjIfwVnOUGq2nbTjTUbmy0DJ/tFIVT30+Qe3nzl4TJg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -8703,16 +7078,6 @@
         "which": "^2.0.2"
       },
       "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -8728,16 +7093,10 @@
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true,
-          "optional": true
         }
       }
     },
@@ -9645,11 +8004,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.16.0.tgz",
-      "integrity": "sha512-LarL/PIKJvc09k1jaeT4kQb/8/7P+qV4qSnN2K80AES+OHdfZELAKVOBjxsvtToT/uLOfFbvYvKfZmV8cee7nA==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "dev": true,
       "requires": {
+        "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -9715,9 +8075,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -9835,7 +8195,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -10725,9 +9086,9 @@
       }
     },
     "universalify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "unset-value": {
       "version": "1.0.0",
@@ -11049,6 +9410,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
       "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yaml": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firemin",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Firebase Firestore/Storage security rules minifier",
   "author": "Brian Neisler <hello@brianneisler.com>",
   "license": "Apache-2.0",

--- a/scripts/js/docs-generate.js
+++ b/scripts/js/docs-generate.js
@@ -4,17 +4,7 @@ import dox from 'dox'
 import fs from 'fs-extra'
 import glob from 'glob'
 import markdownMagic from 'markdown-magic'
-import {
-  append,
-  assoc,
-  filter,
-  find,
-  forEach,
-  isEmpty,
-  map,
-  prop,
-  reduce
-} from 'ramda'
+import { append, assoc, filter, find, forEach, isEmpty, map, prop, reduce } from 'ramda'
 
 import pack from '../../package.json'
 
@@ -45,9 +35,7 @@ const parseReturnsString = (string) => {
     const typesDescription = result[0]
     return {
       description: string.slice(result.index + typesDescription.length).trim(),
-      typesDescription: typesDescription
-        .slice(1, typesDescription.length - 1)
-        .trim()
+      typesDescription: typesDescription.slice(1, typesDescription.length - 1).trim()
     }
   }
   return {}
@@ -118,10 +106,7 @@ const findParams = (tags) => {
 }
 
 const findReturns = (tags) => {
-  const returnsTag = find(
-    (tag) => tag.type === 'return' || tag.type === 'returns',
-    tags
-  )
+  const returnsTag = find((tag) => tag.type === 'return' || tag.type === 'returns', tags)
   return returnsTag
 }
 
@@ -405,29 +390,17 @@ const generateCategoryDocs = (srcData) =>
           if (type === 'function') {
             const fnDocs = generateFunctionDocs(meta, data.srcFile)
             let category = getCategory(fnDocs.category, categories)
-            category = assoc(
-              'functions',
-              append(fnDocs, category.functions),
-              category
-            )
+            category = assoc('functions', append(fnDocs, category.functions), category)
             categories = assoc(fnDocs.category, category, categories)
           } else if (type === 'class') {
             const classDocs = generateClassDocs(meta, data.srcFile)
             let category = getCategory(classDocs.category, categories)
-            category = assoc(
-              'classes',
-              append(classDocs, category.classes),
-              category
-            )
+            category = assoc('classes', append(classDocs, category.classes), category)
             categories = assoc(classDocs.category, category, categories)
           } else {
             const valueDocs = generateValueDocs(meta, data.srcFile)
             let category = getCategory(valueDocs.category, categories)
-            category = assoc(
-              'values',
-              append(valueDocs, category.values),
-              category
-            )
+            category = assoc('values', append(valueDocs, category.values), category)
             categories = assoc(valueDocs.category, category, categories)
           }
         }

--- a/src/minimizer/minimizeAST.js
+++ b/src/minimizer/minimizeAST.js
@@ -3,10 +3,7 @@ import { pipe } from 'ramda'
 import { collapseSingleUseFunctions, removeUnusedFunctions } from './pipes'
 
 const minimizeAST = async (context, ast) => {
-  return pipe(
-    collapseSingleUseFunctions(context),
-    removeUnusedFunctions(context)
-  )(ast)
+  return pipe(collapseSingleUseFunctions(context), removeUnusedFunctions(context))(ast)
 }
 
 export default minimizeAST

--- a/src/minimizer/pipes/collapseSingleUseFunctions.js
+++ b/src/minimizer/pipes/collapseSingleUseFunctions.js
@@ -1,11 +1,7 @@
 import { Map } from 'immutable'
 import { curry, reduce } from 'ramda'
 
-import {
-  buildScopes,
-  collapseFunctionDeclaration,
-  findSingleUseFunctions
-} from '../util'
+import { buildScopes, collapseFunctionDeclaration, findSingleUseFunctions } from '../util'
 
 const collapseSingleUseFunctions = curry((context, ast) => {
   context = {

--- a/src/minimizer/pipes/removeUnusedFunctions.js
+++ b/src/minimizer/pipes/removeUnusedFunctions.js
@@ -1,11 +1,7 @@
 import { Map } from 'immutable'
 import { curry } from 'ramda'
 
-import {
-  buildScopes,
-  findUnusedFunctions,
-  removeFunctionDeclarations
-} from '../util'
+import { buildScopes, findUnusedFunctions, removeFunctionDeclarations } from '../util'
 
 const removeUnusedFunctions = curry((context, ast) => {
   const unusedFunctionIdMap = findUnusedFunctions(

--- a/tests/util/extensions/toEqualPrintDiff.js
+++ b/tests/util/extensions/toEqualPrintDiff.js
@@ -2,8 +2,7 @@ import { keys, omit } from 'ramda'
 
 function toEqualPrintDiff(received, expecteds) {
   const options = {
-    comment:
-      'Checks for a value equality between two objects and prints a usable diff',
+    comment: 'Checks for a value equality between two objects and prints a usable diff',
     isNot: this.isNot,
     promise: this.promise
   }
@@ -20,12 +19,7 @@ function toEqualPrintDiff(received, expecteds) {
   const pass = remainingProps.length === 0
   const message = pass
     ? () =>
-        this.utils.matcherHint(
-          'toHaveReturnedTruthyForValues',
-          undefined,
-          undefined,
-          options
-        ) +
+        this.utils.matcherHint('toHaveReturnedTruthyForValues', undefined, undefined, options) +
         '\n\n' +
         `Expected: ${this.utils.printExpected(expecteds)}\n` +
         `Received: ${this.utils.printReceived(received)}`

--- a/tests/util/extensions/toHaveReturnedFalsyForValues.js
+++ b/tests/util/extensions/toHaveReturnedFalsyForValues.js
@@ -18,12 +18,7 @@ function toHaveReturnedFalsyForValues(func, values) {
   }
 
   const message = () =>
-    this.utils.matcherHint(
-      'toHaveReturnedTruthyForValues',
-      func,
-      `[${value}]`,
-      options
-    ) +
+    this.utils.matcherHint('toHaveReturnedTruthyForValues', func, `[${value}]`, options) +
     '\n\n' +
     `Expected: ${this.utils.printExpected(expected)}\n` +
     `Received: ${this.utils.printReceived(received)}`

--- a/tests/util/extensions/toHaveReturnedTruthyForValues.js
+++ b/tests/util/extensions/toHaveReturnedTruthyForValues.js
@@ -17,12 +17,7 @@ function toHaveReturnedTruthyForValues(func, values) {
   }
 
   const message = () =>
-    this.utils.matcherHint(
-      'toHaveReturnedTruthyForValues',
-      undefined,
-      undefined,
-      options
-    ) +
+    this.utils.matcherHint('toHaveReturnedTruthyForValues', undefined, undefined, options) +
     '\n\n' +
     `Expected: ${this.utils.printExpected(expected)}\n` +
     `Received: ${this.utils.printReceived(received)}`

--- a/tests/util/extensions/toThrowMatchingObject.js
+++ b/tests/util/extensions/toThrowMatchingObject.js
@@ -1,7 +1,6 @@
 function toThrowMatchingObject(func, expected) {
   const options = {
-    comment:
-      'Expects the function to throw an value that matches the given object',
+    comment: 'Expects the function to throw an value that matches the given object',
     isNot: this.isNot,
     promise: this.promise
   }
@@ -22,22 +21,12 @@ function toThrowMatchingObject(func, expected) {
 
   const message = pass
     ? () =>
-        this.utils.matcherHint(
-          'toThrowMatchingObject',
-          undefined,
-          undefined,
-          options
-        ) +
+        this.utils.matcherHint('toThrowMatchingObject', undefined, undefined, options) +
         '\n\n' +
         `Expected: ${this.utils.printExpected(expected)}\n` +
         `Received: ${this.utils.printReceived(received)}`
     : () =>
-        this.utils.matcherHint(
-          'toThrowMatchingObject',
-          undefined,
-          undefined,
-          options
-        ) +
+        this.utils.matcherHint('toThrowMatchingObject', undefined, undefined, options) +
         '\n\n' +
         `Expected: ${this.utils.printExpected(expected)}\n` +
         'Received function did not throw'


### PR DESCRIPTION
- Update API docs
- Break AST parser out into separate module called firetree
- Bump node-notifier from 8.0.0 to 8.0.1
- Add .opensource. Install firetree.
- Bump node-fetch from 2.6.0 to 2.6.1
